### PR TITLE
Two new features, and fixed bugs of zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The controls are slightly different compared to the original Mineshot:
 * Minus: Zoom out
 * Multiply: Turn clipping off
 * Divide: Render full 360 degrees around player
+* Demical dot: Change the background color between sky, red and white
+* Numpad 0: Save the current rotation and zoom level to restore them the next time the ortho view is enabled
+* MOD-key (Left Alt) + Numpad 0: Delete the saved rotation and zoom level
 
 The key-bindings can be changed in the Minecraft Controls menu.
 

--- a/src/main/java/nl/pascalroeleven/minecraft/mineshotrevived/client/OrthoViewHandler.java
+++ b/src/main/java/nl/pascalroeleven/minecraft/mineshotrevived/client/OrthoViewHandler.java
@@ -1,5 +1,6 @@
 package nl.pascalroeleven.minecraft.mineshotrevived.client;
 
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_0;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_1;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_2;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_3;
@@ -8,6 +9,7 @@ import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_5;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_6;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_7;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_8;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_DECIMAL;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_ADD;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_DIVIDE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_MULTIPLY;
@@ -19,6 +21,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.render.Camera;
 import net.minecraft.util.math.Matrix4f;
 import nl.pascalroeleven.minecraft.mineshotrevived.Mineshot;
 import nl.pascalroeleven.minecraft.mineshotrevived.client.config.PropertiesHandler;
@@ -28,7 +31,7 @@ public class OrthoViewHandler {
 	private static final MinecraftClient MC = MinecraftClient.getInstance();
 	private static final PropertiesHandler properties = Mineshot.getPropertiesHandler();
 	private static final String KEY_CATEGORY = "key.categories.mineshotrevived";
-	private static final float ZOOM_STEP = 0.5f;
+	private static final float ZOOM_STEP = 2f;
 	private static final float ROTATE_STEP = 15;
 	private static final float ROTATE_SPEED = 4;
 	private static final float SECONDS_PER_TICK = 1f / 20f;
@@ -59,16 +62,26 @@ public class OrthoViewHandler {
 			GLFW_KEY_LEFT_ALT, KEY_CATEGORY);
 	private final KeyBinding key360 = new KeyBinding("key.mineshotrevived.ortho.render360",
 			GLFW_KEY_KP_DIVIDE, KEY_CATEGORY);
+	private final KeyBinding keyBackground = new KeyBinding("key.mineshotrevived.ortho.background",
+			GLFW_KEY_KP_DECIMAL, KEY_CATEGORY);
+	private final KeyBinding keySaveCam = new KeyBinding("key.mineshotrevived.ortho.save_cam",
+			GLFW_KEY_KP_0, KEY_CATEGORY);
 
 	private boolean enabled;
+	private boolean camSaved;
+
 	private boolean render360;
 	private boolean frustumUpdate;
 	private boolean freeCam;
 	private boolean clip;
+	private int background;
 
 	private float zoom;
 	private float xRot;
 	private float yRot;
+	private float zoomSaved;
+	private float xRotSaved;
+	private float yRotSaved;
 
 	private int tick;
 	private int tickPrevious;
@@ -88,6 +101,8 @@ public class OrthoViewHandler {
 		KeyBindingHelper.registerKeyBinding(keyClip);
 		KeyBindingHelper.registerKeyBinding(keyMod);
 		KeyBindingHelper.registerKeyBinding(key360);
+		KeyBindingHelper.registerKeyBinding(keyBackground);
+		KeyBindingHelper.registerKeyBinding(keySaveCam);
 
 		reset();
 	}
@@ -97,9 +112,12 @@ public class OrthoViewHandler {
 		if (!enabled) {
 			return false;
 		}
-
+		Camera cam = MC.gameRenderer.getCamera();
 		if (!freeCam) {
-			((CameraInvoker) MC.gameRenderer.getCamera()).InvokeSetRotation(yRot + 180, xRot);
+			((CameraInvoker) cam).InvokeSetRotation(yRot + 180, xRot);
+		} else {
+			yRot = cam.getYaw() - 180;
+			xRot = cam.getPitch();
 		}
 
 		return true;
@@ -126,7 +144,7 @@ public class OrthoViewHandler {
 			double partial = tickDelta;
 			double elapsed = ticksElapsed + (partial - partialPrevious);
 			elapsed *= SECONDS_PER_TICK * ROTATE_SPEED;
-			updateZoomAndRotation(elapsed);
+			updateZoomAndRotation(elapsed, false);
 
 			tickPrevious = tick;
 			partialPrevious = partial;
@@ -165,6 +183,10 @@ public class OrthoViewHandler {
 		return matrix4f;
 	}
 
+	public int getBackground() {
+		return background;
+	}
+
 	// Called by KeyboardMixin
 	public void onKeyEvent() {
 		boolean mod = modifierKeyPressed();
@@ -176,44 +198,58 @@ public class OrthoViewHandler {
 			} else {
 				toggle();
 			}
+		} else if (keyBackground.isPressed()) {
+			circleBackground();
 		} else if (!enabled) {
 			return;
 		} else if (keyClip.isPressed()) {
 			clip = !clip;
 		} else if (keyRotateT.isPressed()) {
+			setZoom(zoomSaved);
 			xRot = mod ? -90 : 90;
 			yRot = 0;
 		} else if (keyRotateF.isPressed()) {
+			setZoom(zoomSaved);
 			xRot = 0;
 			yRot = mod ? -90 : 90;
 		} else if (keyRotateS.isPressed()) {
+			setZoom(zoomSaved);
 			xRot = 0;
 			yRot = mod ? 180 : 0;
 		} else if (key360.isPressed()) {
 			render360 = !render360;
 			frustumUpdate = true;
+		} else if (keySaveCam.isPressed()) {
+			if (mod) {
+				camSaved = false;
+			} else {
+				zoomSaved = zoom;
+				xRotSaved = xRot;
+				yRotSaved = yRot;
+				camSaved = true;
+			}
 		}
 
 		// Update stepped rotation/zoom controls
 		// Note: the smooth controls are handled in onWorldRenderer, since they need to be
 		// executed on every frame
 		if (mod) {
-			updateZoomAndRotation(1);
-			// Snap values to step units
-			xRot = Math.round(xRot / ROTATE_STEP) * ROTATE_STEP;
-			yRot = Math.round(yRot / ROTATE_STEP) * ROTATE_STEP;
-			zoom = Math.round(zoom / ZOOM_STEP) * ZOOM_STEP;
+			updateZoomAndRotation(1, true);
 		}
 	}
 
 	private void reset() {
+		if (!camSaved) {
+			zoomSaved = (float) Math.pow(ZOOM_STEP, 3);
+			xRotSaved = Integer.parseInt(properties.get("xRotation"));
+			yRotSaved = Integer.parseInt(properties.get("yRotation"));
+		}
+		zoom = zoomSaved;
+		xRot = xRotSaved;
+		yRot = yRotSaved;
 		freeCam = false;
 		clip = false;
 		render360 = false;
-
-		zoom = 8;
-		xRot = Integer.parseInt(properties.get("xRotation"));
-		yRot = Integer.parseInt(properties.get("yRotation"));
 		tick = 0;
 		tickPrevious = 0;
 		partialPrevious = 0;
@@ -239,38 +275,61 @@ public class OrthoViewHandler {
 		}
 	}
 
+	private void circleBackground() {
+		if (background == 2) {
+			background = 0;
+		} else {
+			background++;
+		}
+	}
+
+	private void setZoom(float d) {
+		zoom = d;
+		// Because zooming is not a native game mechanic, it doesn't trigger a terrain
+		// update
+		if (render360)
+			MC.worldRenderer.scheduleTerrainUpdate();
+	}
+
 	private boolean modifierKeyPressed() {
 		return keyMod.isPressed();
 	}
 
-	private void updateZoomAndRotation(double multi) {
-		if (keyZoomIn.isPressed()) {
-			zoom *= 1 - ZOOM_STEP * multi;
+	private void updateZoomAndRotation(double multi, boolean mod) {
 
-			// Because zooming is not a native game mechanic, it doesn't trigger a terrain update
-			if (render360)
-				MC.worldRenderer.scheduleTerrainUpdate();
+		if (keyZoomIn.isPressed()) {
+			setZoom((float) Math.max(1E-7, (zoom / (1 + ((ZOOM_STEP - 1) * multi)))));
+			if (mod)
+				// zoom = 2^(ceil(log2(zoom)))
+				zoom = (float) Math.pow(ZOOM_STEP, Math.ceil(Math.log10(zoom) / Math.log10(ZOOM_STEP)));
 		}
 		if (keyZoomOut.isPressed()) {
-			zoom *= 1 + ZOOM_STEP * multi;
-
-			// Because zooming is not a native game mechanic, it doesn't trigger a terrain update
-			if (render360)
-				MC.worldRenderer.scheduleTerrainUpdate();
+			setZoom((float) (zoom * (1 + ((ZOOM_STEP - 1) * multi))));
+			if (mod)
+				// zoom = 2^(floor(log2(zoom)))
+				zoom = (float) Math.pow(ZOOM_STEP, Math.floor(Math.log10(zoom) / Math.log10(ZOOM_STEP)));
 		}
 
 		if (keyRotateL.isPressed()) {
 			yRot += ROTATE_STEP * multi;
+			if (mod)
+				yRot = (float) (Math.floor(yRot / ROTATE_STEP) * ROTATE_STEP);
 		}
 		if (keyRotateR.isPressed()) {
 			yRot -= ROTATE_STEP * multi;
+			if (mod)
+				yRot = (float) (Math.ceil(yRot / ROTATE_STEP) * ROTATE_STEP);
 		}
 
 		if (keyRotateU.isPressed()) {
 			xRot += ROTATE_STEP * multi;
+			if (mod)
+				xRot = (float) (Math.floor(xRot / ROTATE_STEP) * ROTATE_STEP);
 		}
 		if (keyRotateD.isPressed()) {
 			xRot -= ROTATE_STEP * multi;
+			if (mod)
+				xRot = (float) (Math.ceil(xRot / ROTATE_STEP) * ROTATE_STEP);
 		}
 	}
 }

--- a/src/main/java/nl/pascalroeleven/minecraft/mineshotrevived/mixin/WorldRendererMixin.java
+++ b/src/main/java/nl/pascalroeleven/minecraft/mineshotrevived/mixin/WorldRendererMixin.java
@@ -2,7 +2,11 @@ package nl.pascalroeleven.minecraft.mineshotrevived.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -32,5 +36,29 @@ public class WorldRendererMixin {
 		} else {
 			return newMatrix4f;
 		}
+	}
+	
+	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;clear(IZ)V"))
+	private void onRenderClear(CallbackInfo ci) {
+		int background = Mineshot.getOrthoViewHandler().getBackground();
+		if (background == 1) {
+			RenderSystem.setShaderFogColor(0, 0, 0, 0);
+			RenderSystem.clearColor(1.0f, 0, 0, 1.0f);
+		} else if (background == 2) {
+			RenderSystem.setShaderFogColor(0, 0, 0, 0);
+			RenderSystem.clearColor(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+	}
+
+	@Inject(method = "renderSky*", at = @At("HEAD"), cancellable = true)
+	private void onRenderSky(CallbackInfo ci) {
+		if (Mineshot.getOrthoViewHandler().getBackground() != 0)
+			ci.cancel();
+	}
+
+	@Inject(method = "renderClouds*", at = @At("HEAD"), cancellable = true)
+	private void onRenderWeather(CallbackInfo ci) {
+		if (Mineshot.getOrthoViewHandler().getBackground() != 0)
+			ci.cancel();
 	}
 }

--- a/src/main/resources/assets/mineshotrevived/lang/en_us.json
+++ b/src/main/resources/assets/mineshotrevived/lang/en_us.json
@@ -14,6 +14,8 @@
 	"key.mineshotrevived.ortho.zoom_in": "Zoom in",
 	"key.mineshotrevived.ortho.zoom_out": "Zoom out",
 	"key.mineshotrevived.ortho.render360": "Render full 360 degrees",
+	"key.mineshotrevived.ortho.background": "Change background",
+	"key.mineshotrevived.ortho.save_cam": "Save the camera settings",
 	"mineshotrevived.config.height": "Capture Height (px)",
 	"mineshotrevived.config.notify_dev": "Notify on dev-versions",
 	"mineshotrevived.config.notify_incompatible": "Notify on incompatible versions",

--- a/src/main/resources/mineshotrevived.mixins.json
+++ b/src/main/resources/mineshotrevived.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "nl.pascalroeleven.minecraft.mineshotrevived.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [


### PR DESCRIPTION
Two new features:
* Pressing numpad point to circle background color between sky, red and white.
* Using numpad 0 can save current rotation and zoom level to restore them the next time you enable the ortho view

Bugs of zoom:
* Zoom can sometimes become 0, or even negative.
* The previous zoom level can never be restored after zooming in or zooming out.
* After zooming in to a certain level, you cannot continue to zoom in with alt+'+'