### PR TITLE
Add camera saving feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The controls are slightly different compared to the original Mineshot:
 * Multiply: Turn clipping off
 * Divide: Render full 360 degrees around player
 * Demical dot: Change the background color between sky, red and white
+* Numpad 0: Save the current rotation and zoom level to restore them the next time the ortho view is enabled
+* MOD-key (Left Alt) + Numpad 0: Delete the saved rotation and zoom level
 
 The key-bindings can be changed in the Minecraft Controls menu.
 

--- a/src/main/resources/assets/mineshotrevived/lang/en_us.json
+++ b/src/main/resources/assets/mineshotrevived/lang/en_us.json
@@ -15,6 +15,7 @@
 	"key.mineshotrevived.ortho.zoom_out": "Zoom out",
 	"key.mineshotrevived.ortho.render360": "Render full 360 degrees",
 	"key.mineshotrevived.ortho.background": "Change background",
+	"key.mineshotrevived.ortho.save_cam": "Save the camera settings",
 	"mineshotrevived.config.height": "Capture Height (px)",
 	"mineshotrevived.config.notify_dev": "Notify on dev-versions",
 	"mineshotrevived.config.notify_incompatible": "Notify on incompatible versions",


### PR DESCRIPTION
Add the feature that you can save the zoom and ratation with Numpad 0 to restore them the next time you enable the ortho view, which makes it possible to capture the same entity or structure with the same size and ratation.